### PR TITLE
Allow dataset to load video files directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project provides a PyTorch implementation of a state-of-the-art video super
 
 ## Training
 
-The main training script is `video_sr.py`. It expects a directory of videos where each video is stored as a folder of PNG frames.
+The main training script is `video_sr.py`. It expects a directory of video files (e.g. MP4, AVI) rather than pre-extracted PNG frames.
 
 ```bash
 python video_sr.py


### PR DESCRIPTION
## Summary
- update `VideoSuperResDataset` to read frames from video files instead of directories of PNG images
- adjust default video directory in script
- update README to mention that the script expects a directory of video files

## Testing
- `python -m py_compile video_sr.py`
