### PR TITLE
Fix LaTeX \mathbb command error

### DIFF
--- a/paper/technical_report.tex
+++ b/paper/technical_report.tex
@@ -1,5 +1,6 @@
 \documentclass{article}
 \usepackage{amsmath}
+\usepackage{amsfonts}
 \usepackage{graphicx}
 \usepackage{hyperref}
 \usepackage{natbib}


### PR DESCRIPTION
## Summary
- add `amsfonts` package so `\mathbb` is available in LaTeX

## Testing
- `pdflatex -interaction=nonstopmode -halt-on-error paper/technical_report.tex` *(fails: command not found)*