### PR TITLE
Fix natbib citation style

### DIFF
--- a/paper/technical_report.tex
+++ b/paper/technical_report.tex
@@ -4,8 +4,8 @@
 \usepackage{graphicx}
 \usepackage{hyperref}
 \usepackage{tikz}
-\usepackage{natbib}
-\usepackage{tikz}
+% Use numeric citation style to avoid author-year warnings
+\usepackage[numbers]{natbib}
 \usetikzlibrary{arrows.meta, positioning}
 \title{Video Super Resolution with Diffusion-Based Refinement}
 \author{Project Report}


### PR DESCRIPTION
## Summary
- enforce numeric citation mode in the technical report to avoid natbib author-year errors

## Testing
- `python -m py_compile video_sr.py`